### PR TITLE
Make port configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apk del build-deps
 ARG AWS_REGION
 ARG AWS_S3_BUCKET
 ARG AWS_S3_ENDPOINT
+ARG PORT
 
 # Start the reactor
-EXPOSE 8080
-CMD node server.js
+EXPOSE ${PORT:-8080}
+CMD node server.js ${PORT:-8080}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker run -d \
   --name tachyon
   -e AWS_REGION=<region> \
   -e AWS_S3_BUCKET=<bucket> \
-  -e AWS_S3_ENDPOINT=<endpoint>
+  -e AWS_S3_ENDPOINT=<endpoint> \
   humanmade/tachyon
 ```
 
@@ -58,6 +58,23 @@ are a few ways to do this:
   --link s3
   -e AWS_S3_ENDPOINT=http://s3:<s3-port>/
   ```
+
+## Running on a custom port
+
+Because the default port for the service is `8080` you can customise this for better compatibility with docker compose and reverse proxies like Traefik that assign dynamic ports for services unless specifically mapped.
+
+Pass the `PORT` environment variable on start up like so:
+
+```yml
+services:
+  tachyon:
+    image: humanmade/tachyon
+    environment:
+      PORT: 8085
+      AWS_REGION: ...
+      AWS_S3_BUCKET: ...
+      AWS_S3_ENDPOINT: ...
+```
 
 ## Vagrant
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tachyon-docker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Containerised server for on the fly image resizing powered by libvips and sharp",
   "main": "node_modules/node-tachyon/server.js",
   "scripts": {


### PR DESCRIPTION
8080 is a commonly used port, in some `docker-composer.yml` set ups, especially when using Taefik, this means you have to map the port eg. `8080:8081` which overrides Traefik's ability to assign a dynamic port and stops you from running multiple instances together.

This allows for setting the port dynamically to avoid needing to extend this container to change it.